### PR TITLE
Add option to append `rel` instead of clobbering

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -46,6 +46,10 @@ String used to change element `target` attribute, leaves `target` unchanged if s
 
 Class added to element when it's external, will leave `class` unchanged if set to `undefined`.
 
+#### appendRel <Boolean>
+
+If `true`, will union the `rel` values to the existing element's `rel` values. Example: Avoid clobbering a social link with `rel="publisher noopener"` when `opts.rel` is `'noopener'`.
+
 ## License
 
 MIT

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "cheerio": "^0.19.0",
     "debug": "^2.2.0",
     "extend": "^3.0.0",
-    "minimatch": "^2.0.10"
+    "minimatch": "^2.0.10",
+    "underscore": "^1.8.3"
   },
   "devDependencies": {
     "metalsmith": "^2.0.1",


### PR DESCRIPTION
This PR adds the `appendRel` option.

Not a breaking change. No performance changes while not enabled (disabled by default).

This change helps for a lot of edge cases, like using `rel="publisher"` or where you want to use `nofollow` --- and you also want to use `noopener` on all external links by default with this plugin (for example).

Simple union of the `rel` values (space separated).

Thanks for your consideration! Please let me know if you need any changes.